### PR TITLE
Fix compatibility hooks not having name arguments

### DIFF
--- a/lua/svmod/compatibility/sh_vcmod.lua
+++ b/lua/svmod/compatibility/sh_vcmod.lua
@@ -1,4 +1,4 @@
-hook.Add("SV_Enabled", function()
+hook.Add("SV_Enabled", "SV_VCModCompatibility", function()
 	if VCMOD then
 		return
 	end

--- a/lua/svmod/compatibility/sv_vcmod.lua
+++ b/lua/svmod/compatibility/sv_vcmod.lua
@@ -1,4 +1,4 @@
-hook.Add("SV_Enabled", function()
+hook.Add("SV_Enabled", "SV_VCModServerCompatibility", function()
 	if not SVMOD.IsVCEnabled and VC then
 		return
 	end


### PR DESCRIPTION
This pull request fixes a couple of VCMod compatibility hooks not having name arguments.