### PR TITLE
[sv_seats.lua] BlacklistedWeapons is nil fix

### DIFF
--- a/lua/svmod/seats/sv_seats.lua
+++ b/lua/svmod/seats/sv_seats.lua
@@ -182,7 +182,7 @@ function SVMOD.Metatable:SV_EnterVehicle(ply)
 		return -4
 	end
 
-	if seat:SV_IsPassengerSeat() then
+	if seat:SV_IsPassengerSeat() and SVMOD.FCFG.BlacklistedWeapons then
 		ply:SetAllowWeaponsInVehicle(true)
 
 		local weapon = ply:GetActiveWeapon()


### PR DESCRIPTION
Hello,
Prevent an error which would make the SVMod crash when a passager enters a vehicle
The fix has been tested on a base gamemode