### PR TITLE
fix spike-strip

### DIFF
--- a/lua/entities/sv_spikestrip/init.lua
+++ b/lua/entities/sv_spikestrip/init.lua
@@ -17,16 +17,25 @@ function ENT:Touch(ent)
 		for _, part in ipairs(ent.SV_Data.Parts) do
 			if part.WheelID then
 				local wheelPos = ent:LocalToWorld(part.Position)
-				local trace = util.TraceLine({
+				local trace = util.TraceHull({
 					start = wheelPos,
 					endpos = wheelPos + Vector(0, 0, -50),
-					filter = ent
+					filter = ent,
+					maxs = Vector(30, 30, 30),
+					mins = Vector(-30, -30, -30),
+					ignoreworld = true
 				})
 				if trace.Entity == self then
-					ent:SV_DealDamageToWheel(part.WheelID, 50)
+					ent:SV_StartPunctureWheel(part.WheelID, 1)
 				end
 			end
 		end
+	end
+end
+
+function ENT:StartTouch(entity)
+	if IsValid(entity) and entity:IsPlayer() then
+		entity:TakeDamage(5, self, self)
 	end
 end
 

--- a/lua/entities/sv_spikestrip/init.lua
+++ b/lua/entities/sv_spikestrip/init.lua
@@ -12,7 +12,11 @@ function ENT:Initialize()
 	self:SetTrigger( true )
 end
 
+local nextTouchCheck = 0
+
 function ENT:Touch(ent)
+	if CurTime() < nextTouchCheck then return end
+	nextTouchCheck = CurTime() + 0.1
 	if ent:GetClass() == "prop_vehicle_jeep" and SVMOD:IsVehicle(ent) then
 		for _, part in ipairs(ent.SV_Data.Parts) do
 			if part.WheelID then

--- a/lua/weapons/sv_spikestrip_spawner/cl_init.lua
+++ b/lua/weapons/sv_spikestrip_spawner/cl_init.lua
@@ -3,3 +3,36 @@ SWEP.PrintName			= 'Spike Strip'
 SWEP.Slot				= 2
 SWEP.SlotPos			= 2
 SWEP.DrawAmmo			= false
+
+local previewModel
+
+function SWEP:Think()
+    if IsValid(previewModel) then
+        local tr = {}
+        tr.start = LocalPlayer():GetShootPos()
+        tr.endpos = LocalPlayer():GetShootPos() + 200 * LocalPlayer():GetAimVector()
+        tr.filter = {LocalPlayer()}
+        local trace = util.TraceLine(tr)
+        previewModel:SetPos(trace.HitPos)
+        previewModel:SetAngles(Angle(0, LocalPlayer():GetAngles().y, 0))
+    else
+        previewModel = ClientsideModel('models/novacars/spikestrip/spikestrip.mdl', RENDERGROUP_BOTH)
+        previewModel:SetRenderMode(RENDERMODE_TRANSCOLOR)
+        previewModel:SetColor(Color(0, 255, 0, 150))
+    end
+end
+
+function SWEP:OnRemove()
+    if previewModel then
+        previewModel:Remove()
+        previewModel = nil
+    end
+end
+
+function SWEP:Holster(weapon)
+    if IsValid(previewModel) then
+        previewModel:Remove()
+        previewModel = nil
+    end
+    return true
+end

--- a/lua/weapons/sv_spikestrip_spawner/init.lua
+++ b/lua/weapons/sv_spikestrip_spawner/init.lua
@@ -5,15 +5,20 @@ include("shared.lua")
 function SWEP:PrimaryAttack()
 	local tr = {}
 	tr.start = self.Owner:GetShootPos()
-	tr.endpos = self.Owner:GetShootPos() + 100 * self.Owner:GetAimVector()
+	tr.endpos = self.Owner:GetShootPos() + 200 * self.Owner:GetAimVector()
 	tr.filter = {self.Owner}
 	local trace = util.TraceLine(tr)
 	if trace.Hit and trace.HitNormal.z > 0.95 then
 		local spikestrip = ents.Create("sv_spikestrip")
 		spikestrip:SetPos(trace.HitPos)
-		spikestrip:SetAngles( Angle(0,90 + self:GetAngles().y,0) )
+		spikestrip:SetAngles( Angle(0,self:GetAngles().y,0) )
 		spikestrip:Spawn()
 		self:Remove()
 		self:SetNextPrimaryFire(CurTime() + 1)
 	end
+end
+
+function SWEP:Holster(weapon)
+	if ( game.SinglePlayer() ) then self:CallOnClient( "Holster" ) end
+	return true
 end


### PR DESCRIPTION
- Correction de la TraceLine qui causait un problème sur les serveurs à faible tickrate. Utilisation de TraceHull pour avoir une zone plus large.
 - Utilisation de SV_StartPunctureWheel au lieu de SV_DealDamageToWheel pour crever entièrement les pneus.
- Ajout d'une prévisualisation pour voir où on place la herse.
- Modification pour placer la herse plus loin.