### PR TITLE
fix(SV_GetDriverSeat): return an entity instead of a vehicle if it have a parent

### DIFF
--- a/lua/svmod/seats/sh_seats.lua
+++ b/lua/svmod/seats/sh_seats.lua
@@ -18,7 +18,7 @@ end
 function SVMOD.Metatable:SV_GetDriverSeat()
 	local parent = self:GetParent()
 
-	if IsValid(parent) then
+	if IsValid(parent) and SVMOD:IsVehicle(parent) then
 		return parent
 	end
 


### PR DESCRIPTION
If your vehicle is parented to an entity, the `SVMOD.Metatable:SV_GetDriverSeat` function can return the parented entity instead of the vehicle.
It's now fix in the PR