### PR TITLE
Fix nil Pump error by checking validity before usage

### DIFF
--- a/lua/entities/sv_gasolinepistol/init.lua
+++ b/lua/entities/sv_gasolinepistol/init.lua
@@ -64,6 +64,7 @@ function ENT:Initialize()
 		end
 	end)
 
+	if not IsValid(self.Pump) then return end
 	local pumpPos = self.Pump:GetPos()
 
 	timer.Create("SV_FillerPistolRope_" .. entIndex, 1, 0, function()


### PR DESCRIPTION
Added a check to ensure self.Pump is valid before accessing its position, preventing errors when the pump entity is missing or invalid.