### PR TITLE
Fix NULL entity crash in DarkRP compatibility hook

### DIFF
--- a/lua/svmod/compatibility/sv_darkrp.lua
+++ b/lua/svmod/compatibility/sv_darkrp.lua
@@ -1,4 +1,9 @@
 hook.Add("canDropWeapon", "SV_DoNotDropGasolinePistol", function(ply, weapon)
+    -- Check if weapon entity is valid before calling GetClass()
+    if not IsValid(weapon) then
+        return
+    end
+    
     if weapon:GetClass() == "weapon_gasolinepistol" then
         return false
     end


### PR DESCRIPTION
**Problem**
The canDropWeapon hook errors with "Tried to use a NULL entity!" when triggered by TakeDamageInfo. During damage processing, the weapon entity can become invalid while the hook chain is still executing.

**Solution**
Added `IsValid(weapon)` check before accessing weapon methods to prevent NULL entity errors during damage processing.

**Testing**
- Tested with various damage scenarios that trigger the hook chain
- No more crashes when TakeDamageInfo events process weapon entities
- Gasoline pistol drop prevention still works correctly when weapon is valid

Fixes the error stack trace:
[svmod-1.5.2] addons/svmod-1.5.2/lua/svmod/compatibility/sv_darkrp.lua:2: Tried to use a NULL entity!

GetClass - [C]:-1
v - addons/svmod-1.5.2/lua/svmod/compatibility/sv_darkrp.lua:2
3. Call - lua/includes/modules/hook.lua:102
4. unknown - gamemodes/policerp/gamemode/modules/base/sv_gamemode_functions.lua:510
5. TakeDamageInfo - [C]:-1